### PR TITLE
docs: Update API documentation to V5 — redirect to live OpenAPI docs

### DIFF
--- a/JWT_SIGNATURE_VERIFICATION.md
+++ b/JWT_SIGNATURE_VERIFICATION.md
@@ -4,8 +4,10 @@ This guide shows how to verify JWT tokens issued by Pointspay services following
 
 ## JWKS Endpoints
 
-- UAT: `https://uat-api.pointspay.com/v4/.well-known/jwks.json`
-- Prod: `https://api.pointspay.com/v4/.well-known/jwks.json`
+- UAT: `https://uat-api.pointspay.com/v5/.well-known/jwks.json`
+- Prod: `https://api.pointspay.com/v5/.well-known/jwks.json`
+
+> For the full interactive API specification, see the [Production ReDoc](https://api.pointspay.com/v5/openapi/redoc) or the [UAT Swagger UI](https://uat-api.pointspay.com/v5/openapi/docs).
 
 ## JWT.IO Standard Compliance
 
@@ -31,7 +33,7 @@ PointsPay token verification follows the JWT.IO standard workflow:
    - Locate public key matching the token's `kid`
 5. **Signature Verification**: Verify RSA signature using RSASSA-PKCS1-v1_5 with SHA-256/SHA-384/SHA-512
 6. **Claims Validation**:
-   - `iss` (issuer): Matches expected PointsPay issuer URL (e.g., `https://api.pointspay.com/v4`)
+   - `iss` (issuer): Matches expected PointsPay issuer URL (e.g., `https://api.pointspay.com/v5`)
    - `aud` (audience): Matches your unique audience
    - `exp` (expiration): Token not expired (with clock skew tolerance)
    - `iat` (issued at): Token issued at reasonable time
@@ -49,7 +51,7 @@ eyJhbGciOiJSUzI1NiIsImtpZCI6InBwLWRlbW8ta2V5LTEiLCJ0eXAiOiJKV1QifQ.eyJjdXIiOiJBR
 
 Fetch the JWKS from the appropriate endpoint (UAT or Prod).
 
-Example: https://uat-api.pointspay.com/.well-known/jwks.json
+Example: https://uat-api.pointspay.com/v5/.well-known/jwks.json
 
 ```json 
 {
@@ -78,7 +80,7 @@ Example: https://uat-api.pointspay.com/.well-known/jwks.json
   "stat": "CAPTURED",
   "pacc": 85,
   "vpa": 1.5,
-  "iss": "https://api.pointspay.com/v4",
+  "iss": "https://api.pointspay.com/v5",
   "amt": 11250,
   "pid": "271d2f32fcbf430080cab16d6810c8cc",
   "oid": "39",
@@ -262,7 +264,7 @@ if __name__ == "__main__":
 import { createRemoteJWKSet, jwtVerify, decodeProtectedHeader } from 'jose';
 
 const JWKS_URL = 'https://{yourDomain}/.well-known/jwks.json';
-const EXPECTED_ISS = 'https://api.pointspay.com/v4';  // Issuer is a URL
+const EXPECTED_ISS = 'https://api.pointspay.com/v5';  // Issuer is a URL
 const EXPECTED_AUD = 'your-audience-here';
 const ALLOWED_ALGORITHMS = ['RS256', 'RS384', 'RS512'];
 
@@ -309,7 +311,7 @@ use phpseclib3\Math\BigInteger;
 use phpseclib3\Crypt\RSA;
 
 $JWKS_URL = 'https://{pointspay_domain}/.well-known/jwks.json';
-$EXPECTED_ISS = 'https://api.pointspay.com/v4';  // Issuer is a URL
+$EXPECTED_ISS = 'https://api.pointspay.com/v5';  // Issuer is a URL
 $EXPECTED_AUD = 'your-audience-here';
 $ALLOWED_ALGORITHMS = ['RS256', 'RS384', 'RS512'];
 
@@ -399,7 +401,7 @@ import java.util.Set;
 
 public class JwtVerifier {
     private static final String JWKS_URL = "https://{yourDomain}/.well-known/jwks.json";
-    private static final String EXPECTED_ISS = "https://api.pointspay.com/v4";
+    private static final String EXPECTED_ISS = "https://api.pointspay.com/v5";
     private static final String EXPECTED_AUD = "your-audience-here";
     private static final Set<JWSAlgorithm> ALLOWED_ALGORITHMS = new HashSet<>(Arrays.asList(
         JWSAlgorithm.RS256, JWSAlgorithm.RS384, JWSAlgorithm.RS512
@@ -449,7 +451,7 @@ Following JWT.IO standards helps avoid these common security issues:
 | **Clock skew** | Minor diff in server times fails exp/iat | ✅ Allow small leeway (e.g. 60s) per JWT spec |
 | **Missing audience check** | Any site could reuse token | ✅ Enforce exact expected audience per merchant |
 | **Expired tokens accepted** | Missing exp validation | ✅ Use library options to require `exp` and validate it |
-| **Issuer not validated** | Token from wrong source accepted | ✅ Validate `iss` claim matches PointsPay issuer URL (e.g., `https://api.pointspay.com/v4`) |
+| **Issuer not validated** | Token from wrong source accepted | ✅ Validate `iss` claim matches PointsPay issuer URL (e.g., `https://api.pointspay.com/v5`) |
 | **Missing required claims** | Token lacks critical claims | ✅ Require `iss`, `aud`, `exp`, `iat` per OIDC/JWT standards |
 
 ---
@@ -458,4 +460,5 @@ Following JWT.IO standards helps avoid these common security issues:
 - **JWT.IO**: https://jwt.io - Interactive JWT debugger and documentation
 - **RFC 7519**: https://tools.ietf.org/html/rfc7519 - JSON Web Token standard
 - **OpenID Connect Discovery**: https://openid.net/specs/openid-connect-discovery-1_0.html
-- **PointsPay API Documentation**: Contact your integration manager for full API docs
+- **PointsPay API Documentation (V5)**: [Production ReDoc](https://api.pointspay.com/v5/openapi/redoc) ・ [UAT Swagger UI](https://uat-api.pointspay.com/v5/openapi/docs)
+- **OpenAPI Spec**: [Production JSON](https://api.pointspay.com/v5/openapi.json) ・ [UAT JSON](https://uat-api.pointspay.com/v5/openapi.json)

--- a/README.md
+++ b/README.md
@@ -1,663 +1,253 @@
 ![image](https://github.com/user-attachments/assets/aff9c589-000d-4898-bc1e-11d67e1ed574)
 
-# Pointspay
+# Pointspay REST API Documentation
 
-REST API Reference
+> **The canonical, always-up-to-date API specification is now served directly from the API itself.**
+> This repository provides a quick-start overview and supplementary guides. For full endpoint details, request/response schemas, and interactive examples, use the links below.
 
-## 1. Introduction
+---
 
-The target audience of this document is Online Merchants who intend to offer Pointspay as an Alternative Payment Method in their checkout process. The purpose of this document is to guide merchant and partner integrations with the Pointspay REST API.
+## Live API Documentation (V5)
 
-## 2. Overview
+| Environment | Interactive Docs (Swagger UI) | Reference Docs (ReDoc) | OpenAPI Spec |
+|:------------|:------------------------------|:-----------------------|:-------------|
+| **UAT / Sandbox** | [uat-api.pointspay.com/v5/openapi/docs](https://uat-api.pointspay.com/v5/openapi/docs) | — | [openapi.json](https://uat-api.pointspay.com/v5/openapi.json) |
+| **Production** | — | [api.pointspay.com/v5/openapi/redoc](https://api.pointspay.com/v5/openapi/redoc) | [openapi.json](https://api.pointspay.com/v5/openapi.json) |
 
-The Pointspay APIs are organized around REST principles. Data objects are represented in JSON.
+> **Which link should I use?**
+> - Use the **UAT Swagger UI** during development — it lets you execute requests directly from the browser against the sandbox.
+> - Use the **Production ReDoc** as the polished reference when building or reviewing your integration.
+> - Download the **OpenAPI JSON** to generate client SDKs (e.g. `openapi-generator`) or import into Postman.
 
-### 2.1. Environments
+---
 
-Live and sandbox environments are available. The endpoints for the two environments are as below:
+## Supplementary Guides in This Repository
 
-| Environment | Endpoint                         |
-|:------------|:---------------------------------|
-| Sandbox     | https://uat-secure.pointspay.com |
-| Live        | https://secure.pointspay.com     |
+| Document | Description |
+|:---------|:------------|
+| [JWT Signature Verification](JWT_SIGNATURE_VERIFICATION.md) | Language-specific code examples (Python, Java, etc.) for verifying `pp_token` JWTs. |
+| [S2S Integration Guide](S2S_INTEGRATION.md) | Technical guide for loyalty programs integrating their earn/burn endpoints with Pointspay. |
+| [S2S Integration One-Pager](S2S_INTEGRATION_ONEPAGER.md) | Executive overview of the split-payment integration for business stakeholders. |
+| [Category-Specific Commissions](REST%20API_Category-Specific%20Commission%20Implementation.md) | Appendix for merchants with category-varying commission rates. |
 
-_Table 1_
+---
 
-You can use your sandbox credentials for authentication on the sandbox endpoint. All transactions made on the sandbox endpoint do not reach live payment networks and program providers. Once you are ready to move to the live environment you can update the endpoint to the live environment
+## Quick-Start Overview
 
-Endpoint URI: is created by appending the API URI to the environment-specific endpoint (Table 1).
+### 1. Environments
 
-e.g., https://secure.pointspay.com/api/v1/payments
+| Environment | API Base URL | Checkout UI |
+|:------------|:-------------|:------------|
+| **UAT / Sandbox** | `https://uat-api.pointspay.com` | `https://uat-secure.pointspay.com` |
+| **Production** | `https://api.pointspay.com` | `https://secure.pointspay.com` |
 
-### 2.2. OAuth Security
+All V5 endpoints are prefixed with `/v5/`:
 
-The API’s will be secured with OAuth 1.0a. OAuth is a protocol originally published in the [RFC-5849](https://datatracker.ietf.org/doc/html/rfc5849) and used for securing access to API.
-
-We would be using OAuth 1.0a in its simplest form. This implementation involves one single step, in which we rely on OAuth signatures for server-to-server authentication.
-
-![image](https://github.com/user-attachments/assets/e9a90364-95a0-4ec1-a046-e102a6b74a62)
-
-### 2.3. Generate certificates to digitally sign the transaction
-
-Follow the below process to generate the keypair to sign the transaction request digitally.
-
-- Generate a private-public key pair and obtain a certificate corresponding to the public certificate. We recommend using an 8192-bit key to accommodate the payload size.
-- The certificate can be either self-signed or signed by a Certificate Authority (CA).
-
-Commands for self-signed certificate generation using openssl command:
-
-| Open SSL Commands                                                                                                                      |
-|:---------------------------------------------------------------------------------------------------------------------------------------|
-| -- Generate private certificate<br>`openssl req -newkey rsa:8192 -nodes -keyout key.pem -x509 -days 1095 -out certificate.cer -sha256` |
-
-Alternatively, the below Java keytool command can be also used:
-
-| Generate a private/public key pair                                                                                                                                                                                                                                                                                                                                                                                           |
-|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `keytool -genkeypair -alias  <<your alias>>  -keys -keyalg RSA -keysize 8192 -dname "CN=<<Name>>" -validity 1095 -storetype PKCS12 -keystore <<KeyStore Name>> -storepass  <<your password>>`<br>e.g.<br>`keytool -genkeypair -alias prod-merchant-signature-keys -keyalg RSA -keysize 8192 -dname </p><p>“CN=prod-merchant” -validity 1095 -storetype PKCS12 -keystore prod-merchant-signature- keys.p12  -storepass 12345` |
-
-| Export the public certificate from a p12/pfx file                                                                                                                                                                                                                                                                                                                     |
-|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `keytool -exportcert -alias <<your alias>>  -keys -storetype PKCS12 -keystore <<your alias >>.p12 -file <<CertificateName>>.cer -rfc -storepass <<your password>>`<br>e.g.<br>`keytool -exportcert -alias prod-merchant-signature-keys -storetype PKCS12 -keystore prod-merchant-signature-keys.p12 -file prod-merchant-public-certificate.cer -rfc -storepass 12345` |
-
-1. Share the public certificate (.cer) file with Pointspay which will be added in the trust store at Pointspay side.
-2. The pem private key file should not be shared with anyone; it should be known only to the merchant.
-
-### 2.4. Import public certificate to verify the response signature
-
-During merchant on-boarding Pointspay will also share a public certificate with the merchant. The merchant can import this certificate in the keystore and use this certificate to verify the response body and signature.
-
-Command to import the public certificate in the merchant’s keystore file:
-
-`keytool -import -trustcacerts -alias <<your alias>> -file <<public certificate file path>>-keystore <<merchant keystore path>>`<br>e.g.<br>`keytool -import -trustcacerts -alias pointspay -file pointspayPublicCertificate.cer -keystore merchant.keystore`
-
-## 3. Payments
-
-### 3.1. Dynamic Pointspay Logo
-
-Pointspay uses a dynamic payment logo. Hence, it is necessary to use the Pointspay dynamic logo URL for while displaying Pointspay as a payment method.
-
-**Sample code**:
-
-Sandbox:
-
-```html
-<img id=”ppc_checkout_btn_img” alt=”Pointspay” src=”https://uat-secure.pointspay.com/checkout/user/btn-img-v2?shop_code=njjs8f2aNlqO”>
-
-<img id=”ppc_payment_btn_img” alt=”FlyingBluePlus” src=”https://uat-secure.pointspay.com/checkout/user/btn-img-v2?shop_code=5fgs8sdfhqF”>
+```
+POST  /v5/payments                              – Initiate a payment
+POST  /v5/refunds                               – Request a full or partial refund
+GET   /v5/refunds/{payment_id}/attempts          – List all refund attempts
+GET   /v5/transactions/{payment_id}/status       – Transaction status with refund breakdown
+GET   /v5/transactions?order_id=ORD-123          – Search transactions by order ID
+GET   /v5/.well-known/openid-configuration       – OIDC discovery
+GET   /v5/.well-known/jwks.json                  – Public keys for JWT verification
 ```
 
-Live:
+### 2. Authentication (V5)
 
-```html
-<img id=”ppc_checkout_btn_img” alt=”Pointspay” src=”https://secure.pointspay.com/checkout/user/btn-img-v2?shop_code=5I0OHYlLpGAW”>
+V5 uses **API-key authentication** — no certificates, keystores, or signature generation required.
 
-<img id=”ppc_payment_btn_img” alt=”FlyingBluePlus” src=”https://secure.pointspay.com/checkout/user/btn-img-v2?shop_code=KIJ6JYl0p86N”>
-```
+| Header | Required | Description |
+|:-------|:---------|:------------|
+| `X-API-Key` | Yes | Your API key, provided during merchant onboarding. |
+| `X-Shop-Code` | Yes | Your shop identifier. |
+| `X-Idempotency-Key` | Yes (payments) / Recommended (refunds) | Unique string (≥ 16 chars, UUID recommended) to prevent duplicate processing. |
 
-Pointspay logo URL takes the following parameters:
+### 3. Payments
 
-| Parameter | Mandatory | Description                                                                                                       |
-|:----------|:----------|:------------------------------------------------------------------------------------------------------------------|
-| shop_code | Y         | - Shop code provided during merchant onboarding.<br>- Max 32 characters.                                          |
-| language  | N         | - Used to display language-specific logo.<br>- 2-character ISO 639-1 language code.<br>- Default language is: en. |
+Initiate a payment by POSTing to `/v5/payments`. The response contains a `href` redirect URL and a `payment_id`. Redirect the shopper to `href` only when `status` is `ACCEPTED`.
 
-_Table 2_
+**Request body:**
 
-### 3.2. Payments API
+| Parameter | Type | Required | Description |
+|:----------|:-----|:---------|:------------|
+| `order_id` | string | Yes | Your order ID (max 64 chars). |
+| `amount` | integer | Yes | Amount in minor units (e.g. USD 100.00 → `10000`). |
+| `currency` | string | Yes | ISO 4217 currency code. |
+| `language` | string | No | ISO 639-1 language code (default: `en`). |
+| `additional_data` | object | No | Dynamic URLs, categories, custom data. |
 
-This API will initiate the Pointspay payment and create and persist the transaction details in the Pointspay system. This API returns the Pointspay payment URL and the generated payment id in the response.
+**Response body:**
 
-The API is secured via OAuth which requires adding OAuth headers and a signature to the request and the response needs to be verified accordingly. Please refer Section 5 below for the details on request-response signatures.
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `timestamp` | integer | Epoch ms when the payment was created. |
+| `href` | string | Redirect URL for the Pointspay checkout (when `ACCEPTED`). |
+| `order_id` | string | Echo of your order ID. |
+| `payment_id` | string | Unique Pointspay payment ID (UUID). |
+| `status` | string | `ACCEPTED` or `REJECTED`. |
 
-| API URI     | /api/v1/payments |
-|:------------|:-----------------|
-| HTTP Method | POST             |
+> See the full schema, error responses, and sample payloads in the [live docs](https://api.pointspay.com/v5/openapi/redoc).
 
-_Table 3_
+### 4. Redirects & IPN Notifications
 
-**Request:**
+After payment, Pointspay communicates the result via:
 
-| Parameter       | Type   | Mandatory | Description                                                                                                                                    |
-|:----------------|:-------|:----------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| shop_code       | string | Y         | - Shop code provided during merchant onboarding.<br>- Max 32 characters.                                                                       |
-| order_id        | string | Y         | - The order id created by merchant.<br>- Max 64 characters.<br>- Allowed characters: [0-9A-Za-z].                                              |
-| amount          | string | Y         | - The payment amount in minor units.<br>- Max 10 characters.<br>- E.g., For a payment amount of USD 100.00, pass value as 10000.               |
-| currency        | string | Y         | - The currency must be same as displayed to the shopper as basket currency.<br>- 3-character ISO 4217 currency code.                           |
-| language        | string | N         | - The language in which the Pointspay payment pages shall be rendered.<br>- 2-character ISO 639-1 language code.<br>- Default language is: en. |
-| additional_data | object | N         | - An optional additional information can be passed as part of the request.<br>- Please refer section 6.                                        |
+1. **Browser redirect** — shopper is sent to your `success`/`failure`/`cancel` URL with `?pp_token=<JWT>` appended.
+2. **IPN callback** — server-to-server POST to your `ipn` URL with the JWT as the body.
 
-_Table 4_
+IPN is sent for **terminal states only**: `SUCCESS` or `FAILED`.
 
-**Response:**
+Dynamic redirect/IPN URLs can be passed per-transaction in `additional_data.dynamic_urls`:
 
-| Parameter      | Type   | Description                                                                                                                                                                                          |
-|:---------------|:-------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| created_at     | string | The Epoch time with milliseconds when the payment transaction was created.<br>e.g. 1694068168722                                                                                                     |
-| href           | string | Payment redirection URL of the Pointspay payment page when the transaction status is ACCEPTED.                                                                                                       |
-| order_id       | string | Order id sent by merchant in the request.                                                                                                                                                            |
-| payment_id     | string | Unique identifier of the payment transaction in Pointspay.                                                                                                                                           |
-| status         | string | The transaction can be in one of the pre-defined statuses: REJECTED, ACCEPTED or FRAUD. You should redirect a shopper to the Pointspay payment page only when a transaction is in *ACCEPTED* status. |
-| status_message | string | A more detailed message about the status.                                                                                                                                                            |
+| Parameter | Description |
+|:----------|:------------|
+| `success` | Redirect URL on successful payment. |
+| `failure` | Redirect URL on failed payment. |
+| `cancel` | Redirect URL when user cancels. |
+| `ipn` | Server-to-server callback URL. |
 
-_Table 5_
+### 5. JWT Verification (`pp_token`)
 
-### 3.3. Redirect shopper to the Pointspay payment application
+V5 replaces the previous OAuth 1.0a signature scheme with signed **JWT tokens**.
 
-Pointspay returns a redirection URI in the response of the Payment API in the href field (Refer Table 5). Before redirecting the shopper to the Pointspay payment application though, the merchant should verify the following points:
+**JWKS endpoints (public keys):**
 
-- The payment response status is ACCEPTED.
-- The order id in the payment response matches the order on your end.
+| Environment | URL |
+|:------------|:----|
+| UAT | `https://uat-api.pointspay.com/v5/.well-known/jwks.json` |
+| Production | `https://api.pointspay.com/v5/.well-known/jwks.json` |
 
-### 3.4. Pointspay redirection back to the merchant web shop
+**Required validations:**
 
-Once the payment is successful, the shopper would be redirected back to your web shop via the return URL specified by you during merchant onboarding, or the dynamic URLs specified in the payment request.
+| Claim | Check |
+|:------|:------|
+| Algorithm | RS256, RS384, or RS512 |
+| `iss` (issuer) | `https://api.pointspay.com/v5` |
+| `aud` (audience) | Your shop code |
+| `exp` (expiration) | Not expired |
 
-You need to provide 3 redirect URLs during onboarding:
+**Redirect token claims** (minimal):
 
-1. **Success link:** The URL to which the shopper would be redirected when the payment is successful.
-2. **Cancel link:** The URL to which the shopper would be redirected if he decides to pay with another payment option.
-3. **Failure link:** The URL to which the shopper would be redirected when the payment fails.
+| Claim | Type | Description |
+|:------|:-----|:------------|
+| `pid` | string | Pointspay payment ID |
+| `oid` | string | Your order ID |
+| `sts` | string | `SUCCESS` or `FAILED` |
 
-All these links can be the same, depending on your application logic. They will all have the following request body parameters submitted by Pointspay while redirection. Pointspay will do HTTP POST form submission for the SUCCESS transaction and HTTP GET for the FAILED or CANCELED transaction. Pointspay will send the following parameters while redirecting.
+**IPN token claims** (full):
 
-| Parameter       | Description                                                                                                                                                                   |
-|:----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| order_id        | Order number supplied by you in the payment request.                                                                                                                          |
-| payment_id      | Unique identifier of the payment which is generated by Pointspay. You use this identifier to specify a Payment, when doing refunds.<br>E.g., 2f47fff25b3e4e7dabe7d8ff8a1a0010 |
-| status          | Status code indicating the status of the request. Few possible status: SUCCESS, FAILED, CANCELED.                                                                             |
-| authorization   | The authorization code associated with the payment processed.                                                                                                                 |
-| oauth_signature | The generated signature, which is unique for each request and ensures the request’s integrity.                                                                                |
+| Claim | Type | Description |
+|:------|:-----|:------------|
+| `oid` | string | Your order ID |
+| `pid` | string | Pointspay payment ID |
+| `rid` | string | Refund ID (present when `typ` = `REFUND`) |
+| `amt` | integer | Amount in minor units |
+| `cur` | string | Currency code |
+| `sts` | string | `SUCCESS` or `FAILED` |
+| `typ` | string | `PAYMENT` or `REFUND` |
 
-_Table 6_
+> **Security:** Never trust redirect URLs alone — always validate the `pp_token` signature server-side.
+> See [JWT_SIGNATURE_VERIFICATION.md](JWT_SIGNATURE_VERIFICATION.md) for code examples in Python, Java, and more.
 
-Merchant should verify the form body parameters and auth signature sent while redirection. The steps to do the same are mentioned in the section 5.3 below.
+### 6. Refunds
 
-**Sample link**
+Request a full or partial refund by POSTing to `/v5/refunds`. Refunds are **asynchronous** — the response returns immediately with `PENDING` status. Use polling or IPN to get the final result.
 
-[https://www.example.com/txn_landing_page](https://www.example.com/txn_landing_page) (merchant redirection URL)
+**Request body:**
 
-**Sample redirection request body**
+| Parameter | Type | Required | Description |
+|:----------|:-----|:---------|:------------|
+| `amount` | integer | Yes | Refund amount in minor units. |
+| `payment_id` | string | Yes | The original Pointspay payment ID. |
+| `refund_reason` | string | No | Reason for refund (max 200 chars). |
 
-```json
-"order_id": "e97f-45aa-9c6d-1f95",
-"payment_id": "eb51e9bb9d2c4166b3b5332273bdff1d",
-"status": "SUCCESS",
-"authorization": "Bj05vcff67cSHA256withRSA550e8400-e29b-41d4-a716-4466554400001693982469",
-"oauth_signature": "dUkcasiWsc00rM5EdctWfvEst+w6tbSgckLDOeC4H3E="
-```
+**Polling for refund status:**
 
-### 3.5. Instant Payment Notification (IPN)
+- `GET /v5/refunds/{payment_id}/attempts` — list all refund attempts with individual statuses.
+- `GET /v5/transactions/{payment_id}/status` — full transaction status including cash/points breakdown and refund attempts.
 
-After the payment has been processed successfully at Pointspay, the Pointspay server sends an HTTP PUT request with parameters to a pre-configured merchant IPN endpoint. If an IPN endpoint URL is specified in the payment request, the Pointspay server sends the notification to that provided endpoint URL. Refer section 6.1 on how to pass the dynamic IPN URL in the payment request.
+**Refund statuses:** `PENDING` → `SUCCESS` or `FAILED` (terminal, immutable).
 
-**Merchant endpoint pre-requisites:**
+### 7. Transaction Status
 
-- Merchant endpoint should be accessible in both HTTP and HTTPS schemes.
-- Merchant endpoint character length should not be greater than 1000 characters.
+`GET /v5/transactions/{payment_id}/status` returns the full transaction lifecycle:
 
-Merchant endpoint should be able to accept a header size up to 8kb. Pointspay will send the following attributes to the merchant endpoint in a form of JSON object:
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `payment_id` | string | Payment UUID. |
+| `order_id` | string | Your order ID. |
+| `status` | string | `SUCCESS`, `PENDING`, `FAILED`, `REFUNDED`, `PARTIALLY_REFUNDED`. |
+| `total_amount` | integer | Original payment in minor units. |
+| `cash_amount` | integer | Cash (card) portion. |
+| `points_amount` | integer | Points portion. |
+| `currency_code` | string | ISO 4217. |
+| `total_refunded` | integer | Sum of all successful refunds. |
+| `refund_attempts` | array | Individual refund attempts with `refund_id`, `status`, `refund_amount`. |
 
-| Parameter  | Description                                                                                                                                                                   |
-|:-----------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| order_id   | Order number supplied by you in the payment request.                                                                                                                          |
-| payment_id | Unique identifier of the payment which is generated by Pointspay. You use this identifier to specify a payment, when doing refunds.<br>E.g., 2f47fff25b3e4e7dabe7d8ff8a1a0010 |
-| status     | Status code indicating the status of the request.<br>Possible status: SUCCESS.                                                                                                |
-| payment_data | Json Object |
-| payment_data.psp_reference | Payment Gateway reference string |
-| payment_data.loyalty_payment | Json Object |
-| payment_data.loyalty_payment.loyalty_program | Loyalty program name. For example "Flying Blue" |
-| payment_data.loyalty_payment.membership_number | Loyalty program member number. A string value. |
-| payment_data.loyalty_payment.points_used | Points used for payment. A string value. |
-| payment_data.currency_payment | Json Object |
-| payment_data.currency_payment.amount | Amount payed. A string value. |
-| payment_data.currency_payment.currency | Paymen Currency, for example "EUR" |
+You can also search by order ID: `GET /v5/transactions?order_id=ORD-123` — useful when you don't have the `payment_id` stored.
 
-_Table 7_
+---
 
-Pointspay also sends an OAuth authorization header with the request. Merchant should verify the request body and signature sent in the request header. The steps to verify the signature are available in section 5.2 below.
+## Key V5 Enhancements vs. Previous Versions
 
-## 4. Refund API
+| Change | Before (V1/V4) | V5 |
+|:-------|:----------------|:---|
+| **Authentication** | OAuth 1.0a with certificate-based signatures | API key headers (`X-API-Key`, `X-Shop-Code`) |
+| **Response verification** | Manual RSA signature verification | Standard JWT (`pp_token`) with JWKS |
+| **Amounts** | Strings (`"10000"`) | Integers (`10000`) |
+| **Refund flow** | Synchronous | Asynchronous with polling & IPN |
+| **Payment breakdown** | Not available | `cash_amount` + `points_amount` fields |
+| **Refund tracking** | Single status | Per-attempt tracking with `refund_id` |
+| **Transaction search** | By `payment_id` only | Also by `order_id` |
+| **Idempotency** | Not supported | `X-Idempotency-Key` header |
 
-You can request a partial or full refund. You can request several partial refunds for the same transaction. The sum of all refunds must not be higher than the total amount of the payment transaction.
+### Migration from V4
 
-The API is secured via OAuth which requires adding OAuth headers and a signature to the request and the response needs to be verified accordingly. Please refer Section 5 below for the details on request-response signatures.
+| V4 Path | V5 Path | Notes |
+|:--------|:--------|:------|
+| `/v4/payments` | `/v5/payments` | No breaking changes (thin wrapper). |
+| `/v4/refunds` | `/v5/refunds` | New async response format. |
+| `/v4/transactions/{id}/status` | `/v5/transactions/{id}/status` | Enhanced response with cash/points breakdown & refund attempts. |
 
-| API URI     | /api/v1/refunds |
-|:------------|:----------------|
-| HTTP Method | POST            |
+---
 
-_Table 8_
+## Dynamic Pointspay Logo
 
-**Request:**
+Use the dynamic logo URL when displaying Pointspay as a payment method:
 
-| Parameter       | Type   | Mandatory | Description                                                                                                                |
-|:----------------|:-------|:----------|:---------------------------------------------------------------------------------------------------------------------------|
-| amount          | string | Y         | - Refund amount in minor units.<br>- Max 10 characters.<br>- E.g., For a refund amount of USD 100.00, pass value as 10000. |
-| payment_id      | string | Y         | The Pointspay payment id provided when the payment was initially created.                                                  |
-| refund_reason   | string | N         | - Reason for refund of the payment.<br>- Max 200 characters.                                                               |
-| additional_data | object | N         | Here optional additional information can be passed as part of the request.<br>Please refer section 6.                      |
+| Environment | Example |
+|:------------|:--------|
+| Sandbox | `https://uat-secure.pointspay.com/checkout/user/btn-img-v2?shop_code=YOUR_SHOP_CODE` |
+| Live | `https://secure.pointspay.com/checkout/user/btn-img-v2?shop_code=YOUR_SHOP_CODE` |
 
-_Table 9_
+| Parameter | Required | Description |
+|:----------|:---------|:------------|
+| `shop_code` | Yes | Shop code provided during onboarding (max 32 chars). |
+| `language` | No | ISO 639-1 language code (default: `en`). |
 
-**Response:**
+---
 
-| Parameter      | Type   | Description                                                                                      |
-|:---------------|:-------|:-------------------------------------------------------------------------------------------------|
-| created_at     | string | The Epoch time with milliseconds when the refund transaction was created.<br>e.g., 1694068168722 |
-| payment_id     | string | Unique identifier of the payment transaction in Pointspay.                                       |
-| refund_amount  | string | Amount refunded in the current refund transaction.                                               |
-| refund_id      | string | Unique identifier of the refund transaction in Pointspay.                                        |
-| status         | string | Transaction can be in one of the predefined statuses: SUCCESS, FAILED, REJECTED.                 |
-| status_message | string | A more detailed message about the status.                                                        |
-
-_Table 10_
-
-## 5. Request/Response signature creation and verification
+## Error Handling
 
-### 5.1. Add Authorization Header and Signature in the request
-
-The request needs to be signed using a digital certificate. Steps to generate the signature:
-
-1. Sort the request body (parameters in Table 4 for payments and Table 9 for refunds) in alphabetical order.
-2. Minify/compress the request body so that it doesn’t contain any white space characters.
-3. Include only non-empty properties in signature.
-4. Append values of OAuth parameters in the body string in the below order to generate the message to be signed.
-
-| OAuth parameter (Refer Table 12 for description) |
-|:-------------------------------------------------|
-| oauth_consumer_key                               |
-| oauth_signature_method                           |
-| oauth_nonce                                      |
-| oauth_timestamp                                  |
-
-_Table 11_
-
-5. Encrypt and sign the message using the private key as the secret key using SHA256withRSA algorithm.
-6. Encode the result using Base-64 encoding.
-7. The generated output is the OAuth signature.
-
-This digital signature will be used in the “Authorization” header sent with the request. An Authorization header contains the below OAuth parameters:
-
-| Parameter              | Mandatory | Description                                                                                          |
-|:-----------------------|:----------|:-----------------------------------------------------------------------------------------------------|
-| oauth_consumer_key     | Y         | The consumer key provided during merchant onboarding.                                                |
-| oauth_signature_method | Y         | Signature method will always be “SHA256withRSA”.                                                     |
-| oauth_nonce            | Y         | A unique string that changes with each transaction. Typically, a UUID.                               |
-| oauth_timestamp        | Y         | A timestamp indicating when the request was created, typically in milliseconds since the UNIX Epoch. |
-| oauth_signature        | Y         | The generated signature, which is unique for each request and ensures the request’s integrity.       |
-
-_Table 12_
-
-**Note:** These parameters must be added in the Authorization Header in the same order as the above table. Also, please ensure the header size doesn’t exceed 8 KB.
-
-e.g.
-
-**Sample Payment Request Header**
-
-```json
-POST /api/v1/payments HTTP/1.1
-Host: https://secure.pointspay.com
-Content-type: application/json
-Authorization: Oauth
- oauth_consumer_key=”WqEdR6HN3vTG2csyH2YVp30ySpITobHR”,
- oauth_signature_method=”SHA256withRSA”,
- oauth_nonce=”550e8400-e29b-41d4-a716-446655440000”,
- oauth_timestamp=”1709912891225”,
- oauth_signature=”dUkcasiWsc00rM5EdctWfvEst+w6tbSgckLDOeC4H3E=”
-```
-
-**Sample Payment Body**
-
-```json
-{“amount”:”10000”,”currency”:”USD”,”language”:”en”,”order_id”:”e97f-45aa-9c6d-1f95”,”shop_code”:”O7iY1ZMoTwFQ”}
-```
-
-**Sample Payment Message to generate signature**
-
-```json
-{“amount”:”10000”,”currency”:”USD”,”language”:”en”,”order_id”:”e97f-45aa-9c6d-1f95”,”shop_code”:”O7iY1ZMoTwFQ”}Bj05vcff67cSHA256withRSA550e8400-e29b-41d4-a716-4466554400001693982469
-```
-
-**Sample code to generate signature body:**
-
-Code to generate alphabetically ordered JSON body and to append the authorization header parameter to generate signature message:
-
-```java
-String sortAndMinifyBody(String body) throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
-    TypeReference<TreeMap<String, Object>> typeRef
-            = new TypeReference<TreeMap<String, Object>>() {};
- 
-    // Read as map
-    TreeMap<String,Object> map = mapper.readValue(body, typeRef);
- 
-    // Sort properties in alphabetical order
-    mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-    return mapper.writeValueAsString(map);
-}
-
-String appendOauthHeaderParams(String orderedAndMinifiedBody) {
-    String oauthConsumerKey = "your_consumer_key";
-    String oauthSignatureMethod = "your_oauth_signature_method";
-    String oauthNonce = "unique_code_for_each_request";
-    String oauthTimestamp = "epoch_timestamp_including_milliseconds";
-    StringBuffer sb = new StringBuffer(orderedAndMinifiedBody);
-    sb.append(oauthConsumerKey);
-    sb.append(oauthSignatureMethod);
-    sb.append(oauthNonce);
-    sb.append(oauthTimestamp);
-    return sb.toString();
-}
-```
-
-Sample code to generate the OAuth signature:
-
-```java
-String generateSignature(String body, Path storePath, String alias, char[] keystorePassword, char[] keyPassword) throws Exception {
-    // Generating an alphabetically sorted and minified json request body string from java object
-    String orderedAndMinifiedBody = sortAndMinifyBody(body);
-    // Appending oauth parameters after the json request body to generate the message to sign.
-    String messageToBeSigned = appendOauthHeaderParams(orderedAndMinifiedBody);
-    // Create a Keystore instance
-    KeyStore keystore = KeyStore.getInstance("PKCS12");
-    String signatureStr;
-    // Create an Input Stream from the “.p12” keypair
-    try(FileInputStream fis = new FileInputStream (storePath.toFile())) {
-        // Load the keystore and get private key by providing keystore password
-        keystore.load(fis, keystorePassword);
-
-        // Set entry password
-        KeyStore.ProtectionParameter entryPassword =
-                new KeyStore.PasswordProtection(keyPassword);
-        KeyStore.PrivateKeyEntry keyEntry = (KeyStore.PrivateKeyEntry) keystore.getEntry(alias, entryPassword);
-        // Get the private key
-        PrivateKey privateKey = keyEntry.getPrivateKey(); 
-        // Create a signature instance of signature object using SHA256withRSA algorithm
-        Signature signature = Signature.getInstance("SHA256withRSA");
-        // Initialize the signature object for signing using the private key
-        signature.initSign(privateKey);
-        // Update the data to be signed
-        signature.update(messageToBeSigned.getBytes(StandardCharsets.UTF_8));
-        // Generates the digital signature 
-        byte[] signatureBytes = signature.sign();
-        // Convert the digital signature into text format
-        signatureStr = Base64.getEncoder().encodeToString(signatureBytes);
-    } 
-    return signatureStr;
-}
-```
-
-### 5.2. Verify response data and signature
-
-Pointspay returns the OAuth authorization parameters in the API response header. The merchant should verify the response body and signature returned in the response header.
-
-**Steps to verify signature:**
-
-1. Sort the response in alphabetical order.
-2. Minify/Compress the response JSON so that it doesn’t contain any white space in the markup. (Simple example: ```{"status":"accepted","status_message":"Transaction is accepted"}```)
-3. Include only non-empty properties for verification.
-4. Append values of OAuth parameters in the response body string in the order specified in Table 11 under section 5.1, to generate the response message.
-5. Retrieve the “oauth_signature” parameter from the response Authorization header.
-6. Decode the “oauth_signature” received from the response Authorization header using the Base64 decoding.
-7. Verify the Base64 decoded response signature with the generated response message bytes using SHA256withRSA algorithm and the public key.
-
-**Sample code to verify response signature:**
-
-Code to append the authorization header parameter to generate message to be verified:
-
-```java
-String sortAndMinifyBody(String body) throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
-    TypeReference<TreeMap<String, Object>> typeRef
-            = new TypeReference<TreeMap<String, Object>>() {};
-
-    // Read as map
-    TreeMap<String,Object> map = mapper.readValue(body, typeRef);
-
-    // Sort properties in alphabetical order
-    mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-    return mapper.writeValueAsString(map);
-}
-
-String appendOauthHeaderParams(String orderedAndMinifiedBody) {
-    String oauthConsumerKey = "your_consumer_key";
-    String oauthSignatureMethod = "your_oauth_signature_method";
-    String oauthNonce = "unique_code_for_each_request";
-    String oauthTimestamp = "epoch_timestamp_including_milliseconds";
-    StringBuffer sb = new StringBuffer(orderedAndMinifiedBody);
-    sb.append(oauthConsumerKey);
-    sb.append(oauthSignatureMethod);
-    sb.append(oauthNonce);
-    sb.append(oauthTimestamp);
-    return sb.toString();
-}
-```
-
-Sample code to verify the OAuth signature:
-
-```java
-boolean verifySignature(String body, String oauthSignature, Path storePath, String alias, char[] keystorePassword, char[] keyPassword) throws Exception {
-    // Generating am alphabetically sorted and minified json response body string from java object
-    String orderdAndMinifiedBody = sortAndMinifyBody(body);
-    // Appending oauth parameters after the json response body to generate the message to sign.
-    String messageToBeVerified = appendOauthHeaderParams(orderdAndMinifiedBody);
-    // Get the signature header from the request
-    byte[] signatureBytes = Base64.getDecoder().decode(oauthSignature);
-    // Create a keystore instance and load the keystore file from your keystore path
-    KeyStore keystore = KeyStore.getInstance("PKCS12");
-    try(FileInputStream fis = new FileInputStream (storePath.toFile())) {
-        keystore.load(fis, keystorePassword);
-        // Set entry password
-        KeyStore.ProtectionParameter entryPassword =
-                new KeyStore.PasswordProtection(keyPassword);
-        KeyStore.PrivateKeyEntry keyEntry = (KeyStore.PrivateKeyEntry) keystore.getEntry(alias, entryPassword);
-        // Get public key from keystore
-        Certificate certificate = keyEntry.getCertificate();
-        PublicKey publicKey = null;
-        if (certificate != null) {
-            publicKey = certificate.getPublicKey();
-        }
-        if (publicKey != null) {
-            // Create a message byte array from the messageToBeVerified string
-            byte[] messageBytes = messageToBeVerified.getBytes(StandardCharsets.UTF_8);
-            // Instantiate the signature object with "SHA256withRSA" algorithm
-            Signature signature = Signature.getInstance("SHA256withRSA");
-            signature.initVerify(publicKey); // Provide public key to the signature object
-            signature.update(messageBytes); // Update the message bytes in the signature object
-            return signature.verify(signatureBytes); // Verify the signature
-        } else {
-            return false;
-        }
-    }
-}
-```
-
-### 5.3. Verify request param and signature in merchant redirection.
-
-The merchant should verify the request body parameters with the signature.
-
-**Sample redirection request body**
-
-```text
-"order_id": "e97f-45aa-9c6d-1f95",
-"payment_id": "eb51e9bb9d2c4166b3b5332273bdff1d",
-"status": "SUCCESS",
-"authorization": "Bj05vcff67cSHA256withRSA550e8400-e29b-41d4-a716-4466554400001693982469",
-"oauth_signature": "dUkcasiWsc00rM5EdctWfvEst+w6tbSgckLDOeC4H3E="
-```
-
-**Verify the order_id**
-
-Verify the order_id in the redirection response body parameter against your order id.
-
-**Steps to verify request param and signature:**
-
-1. Append the parameters order_id, payment_id, status, and authorization from the request body shown in Table 6 above.
-2. Retrieve the “oauth_signature” parameter from the request body.
-3. Verify the request signature with the generated final message using SHA256withRSA algorithm and the public key.
-
-Refer below Java code sample below to verify the request param and signature.
-
-Append values from the request body param to create the message to be verified.
-
-```java
-String createMessageToBeVerified() {
-    String orderId = "Read order_id parameter from the redirect request param";
-    String paymentId = "Read payment_id parameter from the redirect request param";
-    String status = "Read status parameter from the redirect request param";
-    String authorization = "read authorization parameter from the redirect request param";
-    return orderId + paymentId + status + authorization;
-}
-```
-
-Sample code to verify the message with signature:
-
-```java
-boolean verifySignature(String messageToBeVerified, String oauthSignature, Path storePath, String alias, char[] keystorePassword, char[] keyPassword) throws Exception {
-    // Get the signature header from the request
-    byte[] signatureBytes = Base64.getDecoder().decode(oauthSignature);
- 
-    //Create a keystore instance and load the keystore file from your keystore path
-    KeyStore keystore = KeyStore.getInstance("PKCS12");
-    try(FileInputStream fis = new FileInputStream (storePath.toFile())) {
-        keystore.load(fis, keystorePassword);
-        // Set entry password
-        KeyStore.ProtectionParameter entryPassword =
-                new KeyStore.PasswordProtection(keyPassword);
-        KeyStore.PrivateKeyEntry keyEntry = (KeyStore.PrivateKeyEntry) keystore.getEntry(alias, entryPassword);
-        // Get public key from keystore
-        Certificate certificate = keyEntry.getCertificate();
-        PublicKey publicKey = null;
-        if (certificate != null) {
-            publicKey = certificate.getPublicKey();
-        }
-        if (publicKey != null) {
-            // Create a message byte array from the messageToBeVerified string
-            byte[] messageBytes = messageToBeVerified.getBytes(StandardCharsets.UTF_8);
-            // Instantiate the signature object with "SHA256withRSA" algorithm
-            Signature signature = Signature.getInstance("SHA256withRSA");
-            signature.initVerify(publicKey); // Provide public key to the signature object
-            signature.update(messageBytes); // Update the message bytes in the signature object
-            return signature.verify(signatureBytes); // Verify the signature
-        } else { 
-            return false; 
-        } 
-    } 
-} 
-```
-
-## 6. Additional Data
-
-This section contains details of additional information, Merchant may or may not send during payment.
-
-| Parameter    | Type           | Mandatory | Description       |
-|:-------------|:---------------|:----------|:------------------|
-| dynamic_urls | object         | N         | Refer Section 6.1 |
-| categories   | List\<object\> | N         | Refer Section 6.2 |
-| custom_data  | Map\<String, object\> | N         | Refer Section 6.3 |
-
-_Table 13_
-
-### 6.1. Dynamic URLs
-
-You can set up default static URLs for your shop during onboarding or can include them dynamically with each transaction you create. The default static URLs would apply If you don't include them dynamically in each payment request.
-
-If you haven't set the default success, failure and cancel redirect URLs during on-boarding and you are also not sending corresponding dynamic redirection URLs during the payment request, you will get an error (REDIRECT_URL_MISSING) while creating a transaction. Please refer the section 7.2 for more details.
-
-| Parameter | Type   | Mandatory | Description                                                                                                                                     |
-|:----------|:-------|:----------|:------------------------------------------------------------------------------------------------------------------------------------------------|
-| success   | string | N         | - The URL to which the shopper would be redirected when the payment is successful.<br>- 1000 characters maximum.                                |
-| failure   | string | N         | - The URL to which the shopper would be redirected when the payment fails.<br>- 1000 characters maximum.                                        |
-| cancel    | string | N         | - The URL to which the shopper would be redirected when the payment is cancelled by the user.<br>- 1000 characters maximum.                     |
-| ipn       | string | N         | - A merchant endpoint URL to which a notification will be sent after a successful payment.<br>- 1000 characters maximum.<br>- Refer Section 3.5 |
-
-_Table 14_
-
-### 6.2. Categories
-
-It is the list of product categories with amount per category.
-
-| Parameter | Type   | Mandatory | Description                                                                                                                                 |
-|:----------|:-------|:----------|:--------------------------------------------------------------------------------------------------------------------------------------------|
-| amount    | string | N         | - The category-specific amount in minor units.<br>- Max 10 characters.<br>- E.g., For a category amount of USD 100.00, pass value as 10000. |
-| code      | string | N         | - It is the category code. It should be unique for each category.                                                                           |
-
-Please refer to [Category Appendix](https://github.com/pointspay/api-documentation/blob/main/REST%20API_Category-Specific%20Commission%20Implementation.md) for more details about categories.
-
-_Table 15_
-
-### 6.3. Custom Data
-When you need to customize payment and pass additional raw json data you should used this filed. The real example is Transavia integration where we use _custom_data_ to pass additional payment attributes to a transaction in order to pass them to Adyen payment later.
-The JSON mean to be a generic object like
+All error responses follow a consistent JSON format:
+
 ```json
 {
-  "key": "value",
-  "obj2": {
-    "key2": "value2"
-  }
+  "code": "TRANSACTION_NOT_FOUND",
+  "message": "Payment with the provided ID was not found. Please check if Payment ID is valid.",
+  "key": "TRANSACTION_NOT_FOUND"
 }
 ```
 
-## 7. Metadata
+For the full list of error codes and HTTP status codes, see the [live API docs](https://api.pointspay.com/v5/openapi/redoc).
 
-### 7.1. Possible POST/GET response codes
+---
 
-| Code                    | Description                                                                                            |
-|:------------------------|:-------------------------------------------------------------------------------------------------------|
-| 200 OK                  | The request was successful, and the response body contains the representation requested.               |
-| 302 FOUND               | A common redirect response; you can GET the representation at the URI in the Location response header. |
-| 304 NOT MODIFIED        | Your client's cached version of the representation is still up to date.                                |
-| 400 BAD REQUEST         | The request you are sending is not a valid one. It is not aligned with the specs.                      |
-| 401 UNAUTHORIZED        | The supplied credentials, if any, are not sufficient to access the resource.                           |
-| 404 NOT FOUND           | The requested endpoint URI is invalid.                                                                 |
-| 429 TOO MANY REQUESTS   | Your application is sending too many simultaneous requests.                                            |
-| 500 SERVER ERROR        | We couldn't return the representation due to an internal server error.                                 |
-| 503 SERVICE UNAVAILABLE | We are temporarily unable to return the representation. Please wait and try again later.               |
+## Additional Resources
 
-_Table 16_
-
-### 7.2. Possible error codes
-
-| Error code                                              | Error message                                                                                                                                                                                  | HTTP status code |
-|:--------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------|
-| SERVER_ERROR                                            | Server error.                                                                                                                                                                                  | 500              |
-| UNABLE_TO_PROCESS_THE_REQUEST                           | Unable to process the request. Usually happens when external payment networks are unavailable. You can try later.                                                                              | 500              |
-| UNKNOWN_ERROR                                           | An unknown error happened on the server. Please contact Pointspay support if you’re encountering this error persistently.                                                                      | 500              |
-| TRANSACTION_NOT_FOUND                                   | Payment with the provided ID was not found. Please check if Payment ID is valid.                                                                                                               | 404              |
-| INVALID_PARAMETERS                                      | You will get this code when you are sending an invalid request, if one or more parameters in the request are not valid.                                                                        | 400              |
-| SHOP_NOT_FOUND                                          | Merchant cannot be found. Please check your shop code.                                                                                                                                         | 400              |
-| SHOP_STATUS_INVALID                                     | Pointspay payments are not available for the shop code. Please check the status of your account.                                                                                               | 400              |
-| REDIRECT_URL_MISSING                                    | Any one of success, failure or cancel redirection URL is missing for the shop.                                                                                                                 | 500              |
-| INVALID_SHOP_CODE                                       | Shop code is invalid.                                                                                                                                                                          | 400              |
-| INELIGIBLE_TRANSACTION_STATUS                           | You are trying to perform an operation which is not available for the current status of the transaction. For example, a transaction can be refunded only when the payment status is *SUCCESS*. | 500              |
-| CURRENCY_NOT_SUPPORTED                                  | You are using an unsupported currency.                                                                                                                                                         | 400              |
-| REFUND_AMOUNT_EXCEEDED                                  | Refund amount exceeded. You cannot refund more than what was initially paid.                                                                                                                   | 500              |
-| INVALID_CATEGORY                                        | Invalid category                                                                                                                                                                               | 500              |
-| REFUND_CATEGORY_AMOUNT_EXCEED_AVAILABLE_CATEGORY_AMOUNT | Refund category amount exceeds available category amount                                                                                                                                       | 500              |
-| DUPLICATE_CATEGORY                                      | Duplicate category                                                                                                                                                                             | 400              |
-| CATEGORY_AMOUNT_EXCEED_TXN_AMOUNT                       | Category amount exceeds transaction amount                                                                                                                                                     | 400              |
-| REFUND_CATEGORY_AMOUNT_EXCEED_REFUND_TXN_AMOUNT         | Refund category amount exceeds refund transaction amount                                                                                                                                       | 400              |
-| INVALID_OAUTH_TIMESTAMP                                 | The provided OAuth timestamp is invalid or has expired.                                                                                                                                        | 401              |
-| MISSING_AUTHORIZATION_HEADER                            | OAuth Authorization header is missing in the request.                                                                                                                                          | 401              |
-| MISSING_AUTHORIZATION_HEADER_PARAMETERS                 | {{Parameter-Names}} Authorization header parameters are missing in the request.                                                                                                                | 401              |
-| MISSING_AUTHORIZATION_HEADER_PARAMETER                  | {{Parameter-Name}} Authorization header parameter Is missing in the request.                                                                                                                   | 401              |
-| INVALID_AUTHORIZATION_HEADER                            | An invalid OAuth Authorization header format has been passed in the request.                                                                                                                   | 401              |
-| INVALID_OAUTH_CONSUMER_KEY                              | The value for oauth_consumer_key doesn't match an existing key or doesn't have access to the requested API.                                                                                    | 401              |
-| INVALID_OAUTH_SIGNATURE_METHOD                          | The value for oauth_signature_method is invalid or is not supported.                                                                                                                           | 401              |
-| INVALID_OAUTH_NONCE                                     | The value for oauth_nonce was already used. Make sure you send a unique nonce with each request.                                                                                               | 401              |
-| SIGNATURE_VERIFICATION_FAILED                           | OAuth signature verification failed.                                                                                                                                                           | 401              |
-
-_Table 17_
-
-### 7.3. Sample error format
-
-| Sample Error Body                                                                                                                                                  |
-|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `{"code": "TRANSACTION_NOT_FOUND", "message": "Payment with the provided ID was not found. Please check if Payment ID is valid.", "key": "TRANSACTION_NOT_FOUND"}` |
-
-_Table 18_
-
-
+- **Full API Specification:** [Production ReDoc](https://api.pointspay.com/v5/openapi/redoc) ・ [UAT Swagger UI](https://uat-api.pointspay.com/v5/openapi/docs)
+- **OpenAPI JSON:** [Production](https://api.pointspay.com/v5/openapi.json) ・ [UAT](https://uat-api.pointspay.com/v5/openapi.json)
+- **JWT Verification Examples:** [JWT_SIGNATURE_VERIFICATION.md](JWT_SIGNATURE_VERIFICATION.md)
+- **S2S Integration (Loyalty Programs):** [S2S_INTEGRATION.md](S2S_INTEGRATION.md)
+- **Category Commissions:** [Category Appendix](REST%20API_Category-Specific%20Commission%20Implementation.md)


### PR DESCRIPTION
## Summary

This PR rewrites the repository documentation to reflect the **V5 API** and directs users to the canonical, auto-generated API docs served from the endpoints themselves.

### Changes

**README.md** — rewritten as a V5 landing page:
- Prominent links to **[UAT Swagger UI](https://uat-api.pointspay.com/v5/openapi/docs)** and **[Production ReDoc](https://api.pointspay.com/v5/openapi/redoc)** with guidance on which to use
- Quick-start overview covering all V5 endpoints, API-key auth, JWT `pp_token` verification, async refunds, and transaction status
- V4→V5 migration table and key enhancements comparison
- Removed obsolete OAuth 1.0a signature generation/verification code and certificate setup instructions

**JWT_SIGNATURE_VERIFICATION.md** — updated all references from v4 to v5:
- JWKS endpoint URLs and issuer claims
- Code examples (Python, JS, PHP, Java) updated with v5 issuer URLs
- Added links to live API docs

### Why
The API specification is now auto-generated (OpenAPI 3.1) and served directly from the API at `/v5/openapi/redoc` and `/v5/openapi/docs`. Keeping a manually-maintained copy in this repo leads to drift. This PR turns the repo into a quick-start guide that points users to the authoritative source.