### PR TITLE
docs: mark Loyalty Orchestrator API as Planned + link from README

### DIFF
--- a/LOYALTY_ORCHESTRATOR_INTEGRATION.md
+++ b/LOYALTY_ORCHESTRATOR_INTEGRATION.md
@@ -1,9 +1,13 @@
 # Pointspay — Loyalty Orchestrator API Integration Guide
 
+> 🚧 **Status: PLANNED — not yet available.** This API is in design and partner evaluation. The
+> endpoints described below are **not callable yet**; sandbox and production availability will be
+> announced. This guide is shared for early integration planning and feedback — not for live use.
+
 > **Audience**: Technical teams integrating the Pointspay Loyalty Orchestrator API to earn and burn
 > loyalty points across multiple programs through one contract.
 > **Direction**: the client calls Pointspay; Pointspay brokers the four loyalty programs behind one API.
-> **Version**: 1.0 (draft for evaluation) — 2026-06-30
+> **Status**: Planned · **Version**: 1.0 (draft for evaluation) — 2026-06-30
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 | [JWT Signature Verification](JWT_SIGNATURE_VERIFICATION.md) | Language-specific code examples (Python, Java, etc.) for verifying `pp_token` JWTs. |
 | [S2S Integration Guide](S2S_INTEGRATION.md) | Technical guide for loyalty programs integrating their earn/burn endpoints with Pointspay. |
 | [S2S Integration One-Pager](S2S_INTEGRATION_ONEPAGER.md) | Executive overview of the split-payment integration for business stakeholders. |
+| [Loyalty Orchestrator API](LOYALTY_ORCHESTRATOR_INTEGRATION.md) | 🚧 **Planned — not yet available.** Earn & burn loyalty points across multiple programs through one API. Draft for partner evaluation; endpoints are not callable yet. |
 | [Category-Specific Commissions](REST%20API_Category-Specific%20Commission%20Implementation.md) | Appendix for merchants with category-varying commission rates. |
 
 ---


### PR DESCRIPTION
## Why

When #9 merged, it kept the rewritten README (V5 docs landing) and the loyalty guide file — but dropped the follow-up commit that (a) linked the guide from the README and (b) marked it **Planned**. This re-applies both on top of the current README.

## Changes
- **README** → adds a row to *Supplementary Guides in This Repository* for the Loyalty Orchestrator API, tagged **🚧 Planned — not yet available**.
- **LOYALTY_ORCHESTRATOR_INTEGRATION.md** → adds a prominent **Status: PLANNED — not yet available** banner at the top (endpoints not callable yet; shared for evaluation), plus `Status: Planned` on the header line.

No other content changes. The guide itself is already live from #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
